### PR TITLE
Split function for Orthotopes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,8 @@ julia:
   - nightly
 notifications:
   email: false
+script:
+    - julia -e 'Pkg.clone(pwd())'
+    - julia --check-bounds=yes -e 'Pkg.test("Orthotopes", coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("Orthotopes")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/src/Orthotopes.jl
+++ b/src/Orthotopes.jl
@@ -1,7 +1,9 @@
 module Orthotopes
 using Compat
 
-export AbstractOrthotope, Orthotope, update!
+import Base.split
+
+export AbstractOrthotope, Orthotope, update!, split
 
 abstract AbstractOrthotope{T, N}
 
@@ -65,6 +67,19 @@ end
 
 function meets{T1, T2, N}(b1::Orthotope{T1,N}, b2::Orthotope{T2, N})
     b1.min == b2.max || b1.max == b2.min
+end
+
+# Splits an orthotope into two new ones along an axis
+# at a given axis value
+function split{T, N}(b::Orthotope{T,N}, axis::Int, value::T)
+    b1max = copy(b.max)
+    b1max[axis] = value
+
+    b2min = copy(b.min)
+    b2min[axis] = value
+
+    return Orthotope{T, N}(b.min, b1max),
+           Orthotope{T, N}(b2min, b.max)
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,3 +21,10 @@ b = Orthotope{Float64,4}([1.0,2.0,3.0,4.0],[5.0,6.0,7.0,8.0])
 c = Orthotope{Float64,4}([1.1,2.1,3.1,4.1],[4.0,5.0,6.0,7.0])
 
 @test !in(a,c) && in(c,a) && contains(a,c) && !contains(c,a)
+
+# Testing split function
+d = Orthotope{Float64,4}([1.0,2.0,3.0,4.0],[2.0,3.0,4.0,5.0])
+d1, d2 = split(d, 3, 3.5)
+
+@test d1.max[3] == 3.5 && d1.min[3] == 3.0
+@test d2.max[3] == 4.0 && d2.min[3] == 3.5


### PR DESCRIPTION
Add a split function for `Orthotopes` that splits an Orthotope into two along an axis.

The PR also includes a modification to the travis script so that coverage files are actually generated when testing so `Coverage` has something to send to Coveralls. For some reason the default script on travis does not run with `coverage=true`.